### PR TITLE
Update grade_runner to 0.0.12

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,14 +9,15 @@ GIT
 
 GIT
   remote: https://github.com/firstdraft/grade_runner.git
-  revision: beae22e05f5d65349b61891b4f85da73d8829f23
+  revision: ee7a9ec450fbfd8087d0aeadd6be3a31e8ee350c
   specs:
-    grade_runner (0.0.10)
+    grade_runner (0.0.12)
       activesupport (>= 2.3.5)
       faraday-retry (~> 1.0.3)
       octokit (~> 5.0)
       oj (~> 3.13.12)
       rake (~> 13)
+      zip
 
 GIT
   remote: https://github.com/firstdraft/web_git.git
@@ -88,8 +89,8 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     amazing_print (1.4.0)
     annotate (3.2.0)
       activerecord (>= 3.2, < 8.0)
@@ -119,7 +120,7 @@ GEM
       xpath (~> 3.2)
     coderay (1.1.3)
     commonmarker (0.23.6)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.3.4)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -146,7 +147,7 @@ GEM
       railties (>= 5.0.0)
     faker (2.20.0)
       i18n (>= 1.8.11, < 2)
-    faraday (2.7.11)
+    faraday (2.8.1)
       base64
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
@@ -170,7 +171,7 @@ GEM
     http-cookie (1.0.4)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    i18n (1.10.0)
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     indefinite_article (0.2.5)
       activesupport
@@ -209,7 +210,7 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
-    minitest (5.15.0)
+    minitest (5.25.1)
     msgpack (1.5.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
@@ -228,7 +229,7 @@ GEM
       method_source (~> 1.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    public_suffix (4.0.7)
+    public_suffix (5.1.1)
     puma (4.3.12)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -270,7 +271,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
-    rake (13.0.6)
+    rake (13.2.1)
     ransack (3.1.0)
       activerecord (>= 6.0.4)
       activesupport (>= 6.0.4)
@@ -348,7 +349,7 @@ GEM
     thor (1.2.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    tzinfo (1.2.9)
+    tzinfo (1.2.11)
       thread_safe (~> 0.1)
     tzinfo-data (1.2022.1)
       tzinfo (>= 1.0.0)
@@ -372,7 +373,8 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.5.4)
+    zeitwerk (2.6.18)
+    zip (2.0.2)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
> [!IMPORTANT]
> I am covering this in class today

Got this error when running `bundle install` in a fresh codespace so I updated grade_runner to latest.
```
codespace /workspaces/bootstrap-levels $ bundle
Fetching gem metadata from https://rubygems.org/..........
Your bundle is locked to grade_runner (0.0.10), but that version could not be found in any of the sources listed in your Gemfile. If you haven't
changed sources, that means the author of grade_runner (0.0.10) has removed it. You'll need to update your bundle to a version other than
grade_runner (0.0.10) that hasn't been removed in order to install.
codespace /workspaces/bootstrap-levels $ bundle update grade_runner
```